### PR TITLE
Image API rework + RenderTexture2D support

### DIFF
--- a/examples/raylib_texture.rs
+++ b/examples/raylib_texture.rs
@@ -1,6 +1,7 @@
 use imgui::{Context, FontSource};
 use raylib::prelude::*;
-use raylib_imgui_rs::{Renderer, TextureExt};
+use raylib_imgui_rs::{Renderer};
+use raylib_imgui_rs::image::ImageExt;
 
 fn main() {
 	let (mut rl, thread) = raylib::init()
@@ -26,6 +27,7 @@ fn main() {
 			let ui = imgui.new_frame();
 
 			if let Some(_token) = ui.window("Texture").begin() {
+				ui.image_scaled(&texture, 128, 128);
 				ui.image(&texture);
 			}
 		}

--- a/examples/raylib_texture.rs
+++ b/examples/raylib_texture.rs
@@ -26,9 +26,7 @@ fn main() {
 			let ui = imgui.new_frame();
 
 			if let Some(_token) = ui.window("Texture").begin() {
-				// imgui_image creates an imgui::Image from a texture
-				texture.imgui_image()
-					.build(&ui);
+				ui.image(&texture);
 			}
 		}
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -2,35 +2,35 @@ use imgui::{TextureId, Ui};
 use raylib::prelude::{RenderTexture2D, Texture2D};
 
 pub trait TextureLike {
-    fn id(&self) -> u32;
-    fn width(&self) -> u32;
-    fn height(&self) -> u32;
+    fn texture_id(&self) -> u32;
+    fn texture_width(&self) -> u32;
+    fn texture_height(&self) -> u32;
 }
 
 impl TextureLike for Texture2D {
-    fn id(&self) -> u32 {
+    fn texture_id(&self) -> u32 {
         self.id
     }
 
-    fn width(&self) -> u32 {
+    fn texture_width(&self) -> u32 {
         self.width as u32
     }
 
-    fn height(&self) -> u32 {
+    fn texture_height(&self) -> u32 {
         self.height as u32
     }
 }
 
 impl TextureLike for RenderTexture2D {
-    fn id(&self) -> u32 {
+    fn texture_id(&self) -> u32 {
         self.texture.id
     }
 
-    fn width(&self) -> u32 {
+    fn texture_width(&self) -> u32 {
         self.texture.width as u32
     }
 
-    fn height(&self) -> u32 {
+    fn texture_height(&self) -> u32 {
         self.texture.height as u32
     }
 }
@@ -43,12 +43,12 @@ pub trait ImageExt {
 impl ImageExt for Ui {
     fn image_scaled<T: TextureLike>(&self, texture: &T, width: u32, height: u32) {
         imgui::Image::new(
-            TextureId::new(texture.id() as _),
+            TextureId::new(texture.texture_id() as _),
             [width as _, height as _],
         ).build(self);
     }
 
     fn image<T: TextureLike>(&self, texture: &T) {
-        self.image_scaled(texture, texture.width(), texture.height());
+        self.image_scaled(texture, texture.texture_width(), texture.texture_height());
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,0 +1,54 @@
+use imgui::{TextureId, Ui};
+use raylib::prelude::{RenderTexture2D, Texture2D};
+
+pub trait TextureLike {
+    fn id(&self) -> u32;
+    fn width(&self) -> u32;
+    fn height(&self) -> u32;
+}
+
+impl TextureLike for Texture2D {
+    fn id(&self) -> u32 {
+        self.id
+    }
+
+    fn width(&self) -> u32 {
+        self.width as u32
+    }
+
+    fn height(&self) -> u32 {
+        self.height as u32
+    }
+}
+
+impl TextureLike for RenderTexture2D {
+    fn id(&self) -> u32 {
+        self.texture.id
+    }
+
+    fn width(&self) -> u32 {
+        self.texture.width as u32
+    }
+
+    fn height(&self) -> u32 {
+        self.texture.height as u32
+    }
+}
+
+pub trait ImageExt {
+    fn image_scaled<T: TextureLike>(&self, texture: &T, width: u32, height: u32);
+    fn image<T: TextureLike>(&self, texture: &T);
+}
+
+impl ImageExt for Ui {
+    fn image_scaled<T: TextureLike>(&self, texture: &T, width: u32, height: u32) {
+        imgui::Image::new(
+            TextureId::new(texture.id() as _),
+            [width as _, height as _],
+        ).build(self);
+    }
+
+    fn image<T: TextureLike>(&self, texture: &T) {
+        self.image_scaled(texture, texture.width(), texture.height());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 mod frame_state;
 mod maps;
 mod clipboard;
+pub mod image;
 
 use std::ptr;
 use raylib::prelude::*;
@@ -324,43 +325,5 @@ impl Renderer {
 
 			font_texture
 		}
-	}
-}
-
-pub trait TextureLike {
-	fn id(&self) -> u32;
-	fn size(&self) -> [f32; 2];
-}
-
-impl TextureLike for Texture2D {
-	fn id(&self) -> u32 {
-		self.id
-	}
-
-	fn size(&self) -> [f32; 2] {
-		[self.width as f32, self.height as f32]
-	}
-}
-
-impl TextureLike for RenderTexture2D {
-	fn id(&self) -> u32 {
-		self.texture.id
-	}
-
-	fn size(&self) -> [f32; 2] {
-		[self.texture.width as f32, self.texture.height as f32]
-	}
-}
-
-pub trait TextureExt {
-	fn image<T: TextureLike>(&self, texture: &T);
-}
-
-impl TextureExt for Ui {
-	fn image<T: TextureLike>(&self, texture: &T) {
-		imgui::Image::new(
-			TextureId::new(texture.id() as _),
-			texture.size(),
-		).build(self);
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ mod clipboard;
 
 use std::ptr;
 use raylib::prelude::*;
-use imgui::{BackendFlags, ConfigFlags, DrawCmd, DrawIdx, DrawVert, Key, MouseCursor, TextureId};
+use imgui::{BackendFlags, ConfigFlags, DrawCmd, DrawIdx, DrawVert, Key, MouseCursor, TextureId, Ui};
 use imgui::internal::{RawCast, RawWrapper};
 use crate::clipboard::ClipboardBackend;
 use crate::frame_state::FrameState;
@@ -327,15 +327,40 @@ impl Renderer {
 	}
 }
 
-pub trait TextureExt {
-	fn imgui_image(&self) -> imgui::Image;
+pub trait TextureLike {
+	fn id(&self) -> u32;
+	fn size(&self) -> [f32; 2];
 }
 
-impl TextureExt for Texture2D {
-	fn imgui_image(&self) -> imgui::Image {
+impl TextureLike for Texture2D {
+	fn id(&self) -> u32 {
+		self.id
+	}
+
+	fn size(&self) -> [f32; 2] {
+		[self.width as f32, self.height as f32]
+	}
+}
+
+impl TextureLike for RenderTexture2D {
+	fn id(&self) -> u32 {
+		self.texture.id
+	}
+
+	fn size(&self) -> [f32; 2] {
+		[self.texture.width as f32, self.texture.height as f32]
+	}
+}
+
+pub trait TextureExt {
+	fn image<T: TextureLike>(&self, texture: &T);
+}
+
+impl TextureExt for Ui {
+	fn image<T: TextureLike>(&self, texture: &T) {
 		imgui::Image::new(
-			TextureId::new(self.id as _),
-			[self.width() as _, self.height() as _],
-		)
+			TextureId::new(texture.id() as _),
+			texture.size(),
+		).build(self);
 	}
 }


### PR DESCRIPTION
This changes the api of the helper function to be more inline with the normal imgui functions (`ui.button()`, `ui.text()`, etc.) swapping out the previous helper function for a simpler `ui.image(texture)`, as well as `ui.image_scaled(texture, width, height)`.

Additionally, it also adds the ability to use a `RenderTexture2D` instead of just `Texture2D`. This allows for live rendering inside windows. I have also moved this code into its own module as I felt it was starting to get outside the scope of the lib module, but I can move it back if you prefer. 

I have updated the example accordingly and tested it. Let me know what you think of these changes, and thanks once again!